### PR TITLE
feat: add vulnerable package import

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"bytes"
+	"log"
+	"golang.org/x/net/http2"
+)
+
+func main() {
+    log.Println("Hello vulnerable")
+   
+    var buff bytes.Buffer
+    var content = []byte("vulnerable")
+    reader := bytes.NewReader(content)
+    framer := http2.NewFramer(&buff, reader)
+
+    log.Printf("%+v\n", framer)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,7 @@
+module github.com/VinceDeslo/vulnerable
+
+go 1.21.4
+
+require golang.org/x/net v0.10.0
+
+require golang.org/x/text v0.9.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+golang.org/x/net v0.10.0 h1:X2//UzNDwYmtCLn7To6G58Wr6f5ahEAQgKNzv9Y951M=
+golang.org/x/net v0.10.0/go.mod h1:0qNGK6F8kojg2nk9dLZ2mShWaEBan6FAoqfSigmmuDg=
+golang.org/x/text v0.9.0 h1:2sjJmO8cDvYveuX97RDLsxlyUxLl+GHoLxBiRdHllBE=
+golang.org/x/text v0.9.0/go.mod h1:e1OnstbJyHTd6l/uOt8jFFHp6TRDWZR/bV3emEE/zU8=


### PR DESCRIPTION
Simply adds a vulnerable version of the golang.org/x/net/http2 module:

```
✗ Medium severity vulnerability found in golang.org/x/net/http2
  Description: Allocation of Resources Without Limits or Throttling
  Info: https://security.snyk.io/vuln/SNYK-GOLANG-GOLANGORGXNETHTTP2-5958903
  Introduced through: golang.org/x/net/http2@0.10.0
  From: golang.org/x/net/http2@0.10.0
  Fixed in: 0.17.0

✗ High severity vulnerability found in golang.org/x/net/http2
  Description: Denial of Service (DoS)
  Info: https://security.snyk.io/vuln/SNYK-GOLANG-GOLANGORGXNETHTTP2-5953327
  Introduced through: golang.org/x/net/http2@0.10.0
  From: golang.org/x/net/http2@0.10.0
  Fixed in: 0.17.0
```